### PR TITLE
Allow all spark version > 3.1.1 and < 4.0.

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        python-version: [3.6, 3.7, 3.8, 3.9]
-        python-version: [3.7]
+      # We make use of annotations which is only supported from python 3.7 onwards
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        # python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -31,7 +31,7 @@ python -m build
 ### dump dependencies periodically if dependencies changed
 
 ```bash
-py -m pip freeze > requirements.txt
+python -m pip freeze > requirements.txt
 ```
 
 
@@ -39,7 +39,7 @@ py -m pip freeze > requirements.txt
 
 ```bash
 # stop the build if there are Python syntax errors or undefined names
-flake8 src/ --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,*.sql,venv
 # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-flake8 src/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,*.sql,venv
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 #spark
-pyspark==3.2.1
+# Pyspark withField and dropFields which are heavily used in this package are only supported from version 3.1.1 onwards
+pyspark~=3.1, >=3.1.1
 
 #build
 build==0.4.0
 
 #tests
-pytest==7.1.3
-flake8==3.9.1
+pytest~=7.1
+flake8>=4.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["tests"]),
     package_data={"nestedfunctions": ["VERSION"]},
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         REQUIREMENTS
     ],


### PR DESCRIPTION
Hi @golosegor,

I hope this message finds you well. First and foremost, I want to express my gratitude for your work on the [pyspark-nested-fields-functions](https://github.com/golosegor/pyspark-nested-fields-functions) library. It has been an invaluable resource in my work, where I frequently encountered the need for complex `withColumn`, `withField`, `transform`, and `lambda` combinations. I had initially planned to create a similar library myself, but was fortunate to discover your project before embarking on that journey.

In order to integrate this library into my workflow, I found it necessary to extend support for different PySpark versions. This led me to create a fork and experiment with some modifications.

Here's a summary of the changes I've made:

- Extended support for all Spark versions greater than 3.1.1 and less than 4.0.
- Limited Python version support to 3.7 and onwards due to the use of annotations.
- Allowed all pytest versions greater than or equal to 7.1.0.
- Upgraded flake8 to at least version 4.0 to address the issue described [here](https://github.com/python/importlib_metadata/issues/406).

I've done my best to adhere to your established practices, but as I typically use poetry for dependency management, there may be areas where I've deviated. I welcome any feedback or suggestions you may have to improve these changes.

Looking forward to your thoughts.

Best regards,
Brend

